### PR TITLE
Removes scheduler commands

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -31,7 +31,7 @@ return [
     /*
      * If true, scheduler commands will be available.
      */
-    'with-scheduler' => true,
+    'with-scheduler' => false,
 
     /*
      * Here goes the application list of Laravel Service Providers.


### PR DESCRIPTION
This PR addresses the removal of commands related with Laravel `scheduler`.